### PR TITLE
feat: migration added with generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+- Feature: Migration and Generater added for create the required table
+
 - Feature: Added Trifle::Stat for analytics
 
 - Feature: Initial public release

--- a/lib/generators/perilune/install/install_generator.rb
+++ b/lib/generators/perilune/install/install_generator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails/generators/migration'
+
+module Perilune
+  module Generators
+    class InstallGenerator < ::Rails::Generators::Base
+      include Rails::Generators::Migration
+      source_root File.expand_path('templates', __dir__)
+      desc 'add the migrations'
+
+      def self.next_migration_number(*)
+        if @prev_migration_nr
+          @prev_migration_nr += 1
+        else
+          @prev_migration_nr = Time.zone.now.utc.strftime('%Y%m%d%H%M%S').to_i
+        end
+        @prev_migration_nr.to_s
+      end
+
+      def copy_migrations
+        migration_template 'create_periline_tasks.rb', 'db/migrate/create_periline_tasks.rb'
+      end
+    end
+  end
+end

--- a/lib/generators/perilune/install/templates/create_periline_tasks.rb
+++ b/lib/generators/perilune/install/templates/create_periline_tasks.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreatePeriluneTask < ActiveRecord::Migration[7.0]
+  def change # rubocop:disable Metrics/MethodLength
+    create_table :perilune_tasks do |t|
+      t.string :task_klass
+      t.jsonb :attrs
+      t.string :state
+      t.text :tags, array: true, default: []
+      t.jsonb :error_data
+      t.string :task_type
+      t.datetime :processing_at
+      t.datetime :processed_at
+      t.datetime :failed_at
+      t.timestamps
+    end
+  end
+end

--- a/lib/generators/perilune/install/templates/create_periline_tasks.rb
+++ b/lib/generators/perilune/install/templates/create_periline_tasks.rb
@@ -14,5 +14,6 @@ class CreatePeriluneTask < ActiveRecord::Migration[7.0]
       t.datetime :failed_at
       t.timestamps
     end
+    add_index :perilune_tasks, :tags, using: :gin
   end
 end


### PR DESCRIPTION
- Migration template added for perilune_task table
- Install generator added for copy migration into your project 



Steps - 
Step 1 - Add `gem 'perilune'` into your project's gemfile.
Step 2 - Rub `bundle install`.
Step 3 - Run `rails g perilune:install` to add migration into your project.
Step 4 - Run `rake db:migrate`.

Enjoy
